### PR TITLE
clean: Lower schema draft for compatibility

### DIFF
--- a/src/schemas/json/codacy.json
+++ b/src/schemas/json/codacy.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "$id": "https://json.schemastore.org/codacy",
   "title": "JSON schema for Codacy configuration files",
   "description": "Schema for codacy.yml files.",


### PR DESCRIPTION
According to https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md:

> Use the lowest possible schema draft needed, preferably Draft v4, to ensure interoperability with as many supported editors, IDEs and parsers as possible.