### PR TITLE
feature: Add descriptions

### DIFF
--- a/src/schemas/json/codacy.json
+++ b/src/schemas/json/codacy.json
@@ -6,7 +6,6 @@
   "type": "object",
   "definitions": {
     "file_extensions": {
-      "title": "<title for file_extensions>",
       "description": "<description for file_extensions>",
       "type": "array",
       "items": {
@@ -14,17 +13,14 @@
       }
     },
     "file_extension": {
-      "title": "",
       "description": "",
       "type": "string"
     },
     "file_glob": {
-      "title": "",
       "description": "",
       "type": "string"
     },
     "exclude_paths": {
-      "title": "",
       "description": "",
       "type": "array",
       "items": {
@@ -34,12 +30,10 @@
   },
   "properties": {
     "engines": {
-      "title": "",
       "description": "",
       "type": "object",
       "properties": {
         ".*": {
-          "title": "",
           "description": "",
           "type": "object",
           "properties": {
@@ -47,12 +41,10 @@
               "$ref": "#/definitions/exclude_paths"
             },
             "base_sub_dir": {
-              "title": "",
               "description": "",
               "type": "string"
             },
             "extra_values": {
-              "title": "",
               "description": "",
               "type": "object"
             }
@@ -64,12 +56,10 @@
       "$ref": "#/definitions/exclude_paths"
     },
     "languages": {
-      "title": "",
       "description": "",
       "type": "object",
       "properties": {
         ".*": {
-          "title": "",
           "description": "",
           "type": "object",
           "properties": {

--- a/src/schemas/json/codacy.json
+++ b/src/schemas/json/codacy.json
@@ -6,22 +6,20 @@
   "type": "object",
   "definitions": {
     "file_extensions": {
-      "description": "<description for file_extensions>",
+      "description": "One or more file extensions to associate with a programming language.",
       "type": "array",
       "items": {
         "$ref": "#/definitions/file_extension"
       }
     },
     "file_extension": {
-      "description": "",
       "type": "string"
     },
     "file_glob": {
-      "description": "",
       "type": "string"
     },
     "exclude_paths": {
-      "description": "",
+      "description": "One or more glob patterns to exclude files from analysis.",
       "type": "array",
       "items": {
         "$ref": "#/definitions/file_glob"
@@ -30,18 +28,18 @@
   },
   "properties": {
     "engines": {
-      "description": "",
+      "description": "Configures the behavior of specific tools.",
       "type": "object",
       "properties": {
         ".*": {
-          "description": "",
+          "description": "Specific tool to configure.",
           "type": "object",
           "properties": {
             "exclude_paths": {
               "$ref": "#/definitions/exclude_paths"
             },
             "base_sub_dir": {
-              "description": "",
+              "description": "Repository directory on which to start the analysis for the specific tool.",
               "type": "string"
             },
             "extra_values": {
@@ -56,11 +54,11 @@
       "$ref": "#/definitions/exclude_paths"
     },
     "languages": {
-      "description": "",
+      "description": "Configures custom file extensions for programming languages.",
       "type": "object",
       "properties": {
         ".*": {
-          "description": "",
+          "description": "Programming language to configure custom file extensions.",
           "type": "object",
           "properties": {
             "extensions": {


### PR DESCRIPTION
Adds descriptions to the existing objects in the schema.

I noticed that VS Code doesn't display the descriptions for objects under the `".*"` syntax in the schema. If I change the `".*"` to a specific instance of an object they work, though.